### PR TITLE
[AXP202] Add func setLDO3Mode() and fix constants for LDO3 & DC2

### DIFF
--- a/examples/AXP202_Example/AXP202_Example.ino
+++ b/examples/AXP202_Example/AXP202_Example.ino
@@ -88,25 +88,26 @@ void setup()
     // Turn off USB input current limit
     power.setVbusCurrentLimit(XPOWERS_AXP202_VBUS_CUR_LIM_OFF);
 
-    // DC2 700~3500 mV, IMAX=1.6A;
+    // DC2 700~2275 mV, 25mV/step, IMAX=1.6A
     power.setDC2Voltage(700);
 
-    // DC3 700~3500 mV,IMAX=0.7A;
+    // DC3 700~3500 mV, 25mV/step, IMAX=1.2A
     power.setDC3Voltage(3300);
 
-    //LDO2 1800~3300 mV, 100mV/step, IMAX=200mA
+    // LDO2 1800~3300 mV, 100mV/step, IMAX=200mA
     power.setLDO2Voltage(1800);
 
-    //LDO3 700~2275 mV, 100mV/step, IMAX=200mA
+    // LDO3 700~3500 mV, 25mV/step, IMAX=200mA
     power.setLDO3Voltage(1800);
 
-    /*  LDO4 Range:
-        1250, 1300, 1400, 1500, 1600, 1700, 1800, 1900,
-        2000, 2500, 2700, 2800, 3000, 3100, 3200, 3300
+    // LDO4 1800~3300 mV, 100mV/step, IMAX=200mA
+    /* LDO4 Range:
+       1250, 1300, 1400, 1500, 1600, 1700, 1800, 1900,
+       2000, 2500, 2700, 2800, 3000, 3100, 3200, 3300
     */
     power.setLDO4Voltage(3300);
 
-    //LDOio 1800~3300 mV, 100mV/step, IMAX=50mA
+    // LDOio 1800~3300 mV, 100mV/step, IMAX=50mA
     power.setLDOioVoltage(3300);
 
 

--- a/src/REG/AXP202Constants.h
+++ b/src/REG/AXP202Constants.h
@@ -152,13 +152,13 @@
 #define XPOWERS_AXP202_LDO2_VOL_STEPS                   (100u)
 #define XPOWERS_AXP202_LDO2_VOL_BIT_MASK                (4u)
 
-#define XPOWERS_AXP202_LDO3_VOL_MIN                     (1800u)
-#define XPOWERS_AXP202_LDO3_VOL_MAX                     (3300u)
-#define XPOWERS_AXP202_LDO3_VOL_STEPS                   (100u)
+#define XPOWERS_AXP202_LDO3_VOL_MIN                     (700u)
+#define XPOWERS_AXP202_LDO3_VOL_MAX                     (3500u)
+#define XPOWERS_AXP202_LDO3_VOL_STEPS                   (25u)
 
 #define XPOWERS_AXP202_DC2_VOL_STEPS                    (25u)
 #define XPOWERS_AXP202_DC2_VOL_MIN                      (700u)
-#define XPOWERS_AXP202_DC2_VOL_MAX                      (3500u)
+#define XPOWERS_AXP202_DC2_VOL_MAX                      (2275u)
 
 #define XPOWERS_AXP202_DC3_VOL_STEPS                    (25u)
 #define XPOWERS_AXP202_DC3_VOL_MIN                      (700u)

--- a/src/XPowersAXP202.tpp
+++ b/src/XPowersAXP202.tpp
@@ -99,6 +99,11 @@ typedef enum {
     XPOWERS_AXP202_BACKUP_BAT_CUR_400UA,
 } xpowers_axp202_backup_batt_curr_t;
 
+typedef enum {
+    XPOWERS_AXP202_LDO3_MODE_LDO,
+    XPOWERS_AXP202_LDO3_MODE_DCIN
+} xpowers_axp202_ldo3_mode_t;
+
 
 class XPowersAXP202 :
     public XPowersCommon<XPowersAXP202>, public XPowersLibInterface
@@ -642,6 +647,26 @@ public:
         return clrRegisterBit(XPOWERS_AXP202_LDO234_DC23_CTL, 6);
     }
 
+    //! Only AXP202 support
+    bool isLDO3LDOMode(void)
+    {
+        return getRegisterBit(XPOWERS_AXP202_LDO3OUT_VOL, 7);
+    }
+
+    //! Only AXP202 support
+    void setLDO3Mode(xpowers_axp202_ldo3_mode_t mode)
+    {
+        switch (mode) {
+        case XPOWERS_AXP202_LDO3_MODE_LDO:
+            clrRegisterBit(XPOWERS_AXP202_LDO3OUT_VOL, 7);
+            break;
+        case XPOWERS_AXP202_LDO3_MODE_DCIN:
+            setRegisterBit(XPOWERS_AXP202_LDO3OUT_VOL, 7);
+            break;
+        default:
+            break;
+        }
+    }
 
     bool setLDO3Voltage(uint16_t millivolt)
     {


### PR DESCRIPTION
照着手里不一定是最新版的`datasheet`和旧库[AXP202X_Library](https://github.com/lewisxhe/AXP202X_Library)捋了好几遍，应该没有改错

Close #41 

<img width="325" alt="image" src="https://github.com/user-attachments/assets/68a51007-9391-42c4-908c-b1f918796444" />
