### PR TITLE
Remove i2c dev handle on deinit

### DIFF
--- a/src/XPowersAXP2101.tpp
+++ b/src/XPowersAXP2101.tpp
@@ -508,11 +508,11 @@ public:
     }
 
     /**
-     * @brief  Compare Gauge Data
-     * @note   This function compares the provided gauge data with the data in the gauge.
+     * @brief  Write Gauge Data
+     * @note   This function writes the provided gauge data to battery parameter.
      * @param  *data: Pointer to the data buffer to compare.
      * @param  len: Length of the data buffer (should be 128 bytes).
-     * @retval True if the data matches, false otherwise.
+     * @retval True if the data successfully wrote to ROM by comparing with the written data, false otherwise.
      */
     bool writeGaugeData(uint8_t *data, uint8_t len)
     {


### PR DESCRIPTION
If the i2c_device is initialized by the class then it should also detach the device handle on deinit() function at the end of its lifecycle. 

One of the use case is I'd like to remove the i2c master bus but I have to remove all associated device first. The i2c needed to be removed from the PMU class. 


Also added the fix for docstring of writeGaugeData function. 