### PR TITLE
AXP2101: Fix bitmask associated with precharge current

### DIFF
--- a/src/XPowersAXP2101.hpp
+++ b/src/XPowersAXP2101.hpp
@@ -2465,13 +2465,13 @@ public:
     {
         int val = readRegister(XPOWERS_AXP2101_IPRECHG_SET);
         if (val == -1)return;
-        val &= 0xFC;
+        val &= 0xF0;
         writeRegister(XPOWERS_AXP2101_IPRECHG_SET, val | opt);
     }
 
     xpowers_prechg_t getPrechargeCurr(void)
     {
-        return (xpowers_prechg_t)(readRegister(XPOWERS_AXP2101_IPRECHG_SET) & 0x03);
+        return (xpowers_prechg_t)(readRegister(XPOWERS_AXP2101_IPRECHG_SET) & 0x0F);
     }
 
 


### PR DESCRIPTION
As per v1.4 datasheet the precharge current is occupying the lower 4 bits of REG61. The previous bit mask mistakenly considered the bit mask is only 2 bits in length. 

<img width="1563" height="1012" alt="image" src="https://github.com/user-attachments/assets/2899de28-e0bb-4e54-910d-168a418b0a3e" />
